### PR TITLE
Fix convertIndis: bring back removed indi convert for each individual

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -112,6 +112,7 @@ class Writer
         $output = '';
         foreach ($indis as $indi) {
             if ($indi) {
+                $output .= Indi::convert($indi);
                 foreach ($indi->getEven() as $eventType => $events) {
                     foreach ($events as $event) {
                         $output .= Indi::convertEvent($event, $eventType);


### PR DESCRIPTION
`Indi::convert($item)` was removed from `convertIndis` in this PR https://github.com/liberu-genealogy/php-gedcom/pull/15 but I think it's necessary to export individuals, otherwise names and other attributes would not be exported.