### PR TITLE
Fix getEven return type on Indi

### DIFF
--- a/src/Record/Indi.php
+++ b/src/Record/Indi.php
@@ -342,6 +342,8 @@ class Indi extends \Gedcom\Record implements Noteable, Objectable, Sourceable
         if (isset($this->even[strtoupper((string) $key)])) {
             return $this->even[strtoupper((string) $key)];
         }
+
+        return [];
     }
 
     /**


### PR DESCRIPTION
The `getEven` function is supposed to return an array, but if the `$key` is not found it will return just null, making [this line](https://github.com/albarin/php-gedcom/blob/fix-indi-get-even-return/src/Writer.php#L116) to cause an error:
<img width="1183" alt="Screenshot 2024-08-18 at 12 59 34" src="https://github.com/user-attachments/assets/a51984fb-bd18-4cb1-80e3-5eba96c34978">

With this PR I'm making the `getEven` to return an empty array if the `$key` is not found, solving that error.