### PR TITLE
Fix add phone function in the event parser

### DIFF
--- a/src/Parser/Fam/Even.php
+++ b/src/Parser/Fam/Even.php
@@ -59,7 +59,7 @@ class Even extends \Gedcom\Parser\Component
                     break;
                 case 'PHON':
                     $phone = \Gedcom\Parser\Phon::parse($parser);
-                    $even->addPhone($phone);
+                    $even->addPhon($phone);
                     break;
                 case 'CAUS':
                     $even->setCaus(trim((string) $record[2]));


### PR DESCRIPTION
@curtisdelicata The function should be `addPhon` instead of `addPhone`, otherwise it throws the following error:
<img width="1182" alt="Screenshot 2024-08-20 at 07 04 59" src="https://github.com/user-attachments/assets/753b3825-df98-4bda-82f7-ab26c7259598">
