### PR TITLE
Allow to store multiple family events of the same type

### DIFF
--- a/src/Record/Fam.php
+++ b/src/Record/Fam.php
@@ -49,7 +49,13 @@ class Fam extends \Gedcom\Record implements Noteable, Sourceable, Objectable
 
     public function addEven($recordType, $even)
     {
-        $this->_even[$recordType] = $even;
+        if (!array_key_exists($recordType, $this->_even)) {
+            $this->_even[$recordType] = [];
+        }
+
+        $this->_even[$recordType][] = $even;
+
+        return $this;
     }
 
     /**
@@ -61,12 +67,18 @@ class Fam extends \Gedcom\Record implements Noteable, Sourceable, Objectable
     }
 
     /**
-     * @return void|\Gedcom\Record\Fam\Even
+     * @return void|\Gedcom\Record\Fam\Even|\Gedcom\Record\Fam\Even[]
      */
     public function getEven($key = '')
     {
-        if (isset($this->_even[strtoupper((string) $key)])) {
-            return $this->_even[strtoupper((string) $key)];
+        $key = strtoupper((string) $key);
+
+        if (isset($this->_even[$key])) {
+            if (count($this->_even[$key]) === 1) {
+                return $this->_even[$key][0];
+            }
+
+            return $this->_even[$key];
         }
     }
 

--- a/src/Writer/Fam.php
+++ b/src/Writer/Fam.php
@@ -139,10 +139,12 @@ class Fam
         // EVEN
         $even = $fam->getAllEven();
         if (!empty($even) && $even !== []) {
-            foreach ($even as $eventType => $item) {
-                if ($item) {
-                    $_convert = \Gedcom\Writer\Fam\Even::convert($item, $eventType, $level);
-                    $output .= $_convert;
+            foreach ($even as $eventType => $items) {
+                foreach ($items as $item) {
+                    if ($item) {
+                        $_convert = \Gedcom\Writer\Fam\Even::convert($item, $eventType, $level);
+                        $output .= $_convert;
+                    }
                 }
             }
         }

--- a/tests/library/Gedcom/FamParserTest.php
+++ b/tests/library/Gedcom/FamParserTest.php
@@ -37,7 +37,7 @@ class FamParserTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $events);
 
         $eventType = array_keys($events)[0];
-        $event = $events[$eventType];
+        $event = $events[$eventType][0];
 
         $this->assertEquals('MARR', $eventType);
         $this->assertEquals('MARR', $event->getType());
@@ -56,9 +56,66 @@ class FamParserTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $events);
 
         $eventType = array_keys($events)[0];
-        $event = $events[$eventType];
+        $event = $events[$eventType][0];
 
         $this->assertEquals('MARR', $eventType);
         $this->assertEquals('Civil marriage', $event->getType());
+    }
+
+    /**
+     * Test multiple events of the same type are kept.
+     */
+    public function testMultipleEventsOfTheSameTypeAreKept()
+    {
+        $this->gedcom = $this->parser->parse(\TEST_DIR.'/stresstestfiles/family/family_multiple_events.ged');
+        $fam = $this->gedcom->getFam('F1');
+
+        $events = $fam['F1']->getAllEven();
+        $this->assertCount(2, $events['MARR']);
+
+        $eventTypes = array_keys($events);
+        $this->assertEquals('MARR', $eventTypes[0]);
+
+        $event1 = $events['MARR'][0];
+        $event2 = $events['MARR'][1];
+
+        $this->assertEquals('First civil marriage', $event1->getType());
+        $this->assertEquals('Second civil marriage', $event2->getType());
+    }
+
+    /**
+     * Test get even returns a single event.
+     */
+    public function testGetEvenReturnsASingleEvent()
+    {
+        $this->gedcom = $this->parser->parse(\TEST_DIR.'/stresstestfiles/family/family_event_with_type.ged');
+
+        $fam = $this->gedcom->getFam('F1');
+
+        $event = $fam['F1']->getEven('MARR');
+        $this->assertInstanceOf(\Gedcom\Record\Fam\Even::class, $event);
+
+        $this->assertEquals('Civil marriage', $event->getType());
+    }
+
+    /**
+     * Test get even returns multiple events.
+     */
+    public function testGetEvenReturnsMultipleEvents()
+    {
+        $this->gedcom = $this->parser->parse(\TEST_DIR.'/stresstestfiles/family/family_multiple_events.ged');
+
+        $fam = $this->gedcom->getFam('F1');
+
+        $events = $fam['F1']->getEven('MARR');
+        $this->assertCount(2, $events);
+
+        $event1 = $events[0];
+        $event2 = $events[1];
+        $this->assertInstanceOf(\Gedcom\Record\Fam\Even::class, $event1);
+        $this->assertInstanceOf(\Gedcom\Record\Fam\Even::class, $event2);
+
+        $this->assertEquals('First civil marriage', $event1->getType());
+        $this->assertEquals('Second civil marriage', $event2->getType());
     }
 }

--- a/tests/library/Gedcom/FamWriterTest.php
+++ b/tests/library/Gedcom/FamWriterTest.php
@@ -43,6 +43,7 @@ class FamWriterTest extends TestCase
         return [
             [\TEST_DIR.'/stresstestfiles/family/family_event_no_type.ged'],
             [\TEST_DIR.'/stresstestfiles/family/family_event_with_type.ged'],
+            [\TEST_DIR.'/stresstestfiles/family/family_multiple_events.ged'],
         ];
     }
 }

--- a/tests/stresstestfiles/family/family_multiple_events.ged
+++ b/tests/stresstestfiles/family/family_multiple_events.ged
@@ -1,0 +1,6 @@
+0 @F1@ FAM 
+1 MARR
+2 TYPE First civil marriage
+1 MARR
+2 TYPE Second civil marriage
+0 TRLR


### PR DESCRIPTION
Before, when there were two events of the same type they were overwritten and only the last one was kept.
This PR fixes this issue storing them in an array, in a similar way of the [events for Individuals](https://github.com/albarin/php-gedcom/blob/main/src/Record/Indi.php#L316-L327).

@curtisdelicata 