### PR TITLE
Fix `Famc` class trying to access `Fams` and `Sour` methods

### DIFF
--- a/src/Writer/Indi/Famc.php
+++ b/src/Writer/Indi/Famc.php
@@ -27,8 +27,8 @@ class Famc
     {
         $output = '';
         // NAME
-        $_famc = $famc->getFams();
-        if (empty($_fams)) {
+        $_famc = $famc->getFamc();
+        if (empty($_famc)) {
             return $output;
         }
         $output .= $level.' FAMC @'.$_famc."@\n";
@@ -42,7 +42,7 @@ class Famc
         }
 
         // note
-        $note = $famc->getSour();
+        $note = $famc->getNote();
         if (!empty($note) && (is_countable($note) ? count($note) : 0) > 0) {
             foreach ($note as $item) {
                 $_convert = \Gedcom\Writer\NoteRef::convert($item, $level);


### PR DESCRIPTION
Fams and Sour are not available in Famc, so it was throwing an error.
@curtisdelicata 