### PR TITLE
Add support for extension tags

### DIFF
--- a/src/Parser/Fam.php
+++ b/src/Parser/Fam.php
@@ -126,7 +126,11 @@ class Fam extends \Gedcom\Parser\Component
                     break;
 
                 default:
-                    $parser->logUnhandledRecord(self::class.' @ '.__LINE__);
+                    if (strpos($recordType, '_') === 0) {
+                        $fam->addExtensionTag($recordType, $record[2]);
+                    }
+
+                    $parser->logUnhandledRecord(self::class . ' @ ' . __LINE__);
             }
 
             $parser->forward();

--- a/src/Record/Extendable.php
+++ b/src/Record/Extendable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Gedcom\Record;
+
+interface Extendable
+{
+    public function addExtensionTag(string $tag, string $value);
+
+    public function getExtensionTag(string $tag): string;
+}

--- a/src/Record/Fam.php
+++ b/src/Record/Fam.php
@@ -15,7 +15,7 @@
 
 namespace Gedcom\Record;
 
-class Fam extends \Gedcom\Record implements Noteable, Sourceable, Objectable
+class Fam extends \Gedcom\Record implements Noteable, Sourceable, Objectable, Extendable
 {
     protected $_id;
 
@@ -46,6 +46,8 @@ class Fam extends \Gedcom\Record implements Noteable, Sourceable, Objectable
     protected $_sour = [];
 
     protected $_obje = [];
+
+    protected $_extensiontags = [];
 
     public function addEven($recordType, $even)
     {
@@ -105,5 +107,23 @@ class Fam extends \Gedcom\Record implements Noteable, Sourceable, Objectable
     public function addObje($obje = [])
     {
         $this->_obje[] = $obje;
+    }
+
+    public function addExtensionTag($tag, $value)
+    {
+        if (strpos($tag, '_') !== 0) {
+            $tag = "_$tag";
+        }
+
+        $this->_extensiontags[$tag] = $value;
+    }
+
+    public function getExtensionTag(string $tag): string
+    {
+        if (!isset($this->_extensiontags["_$tag"])) {
+            return '';
+        }
+
+        return $this->_extensiontags["_$tag"];
     }
 }

--- a/src/Writer/Fam.php
+++ b/src/Writer/Fam.php
@@ -149,6 +149,16 @@ class Fam
             }
         }
 
+        // Custom tags
+        $extensionTags = $fam->getExtensionTags();
+        if (!empty($extensionTags) && (is_countable($extensionTags) ? count($extensionTags) : 0) > 0) {
+            foreach ($extensionTags as $tag => $value) {
+                if ($value) {
+                    $output .= $level . ' ' . $tag . ' ' . $value . "\n";
+                }
+            }
+        }
+
         return $output;
     }
 }

--- a/tests/library/Gedcom/FamParserTest.php
+++ b/tests/library/Gedcom/FamParserTest.php
@@ -29,7 +29,7 @@ class FamParserTest extends \PHPUnit\Framework\TestCase
      */
     public function testFamilyEventWithNoTypeIsParsed()
     {
-        $this->gedcom = $this->parser->parse(\TEST_DIR.'/stresstestfiles/family/family_event_no_type.ged');
+        $this->gedcom = $this->parser->parse(\TEST_DIR . '/stresstestfiles/family/family_event_no_type.ged');
 
         $fam = $this->gedcom->getFam('F1');
 
@@ -48,7 +48,7 @@ class FamParserTest extends \PHPUnit\Framework\TestCase
      */
     public function testFamilyEventWithTypeIsParsed()
     {
-        $this->gedcom = $this->parser->parse(\TEST_DIR.'/stresstestfiles/family/family_event_with_type.ged');
+        $this->gedcom = $this->parser->parse(\TEST_DIR . '/stresstestfiles/family/family_event_with_type.ged');
 
         $fam = $this->gedcom->getFam('F1');
 
@@ -67,7 +67,7 @@ class FamParserTest extends \PHPUnit\Framework\TestCase
      */
     public function testMultipleEventsOfTheSameTypeAreKept()
     {
-        $this->gedcom = $this->parser->parse(\TEST_DIR.'/stresstestfiles/family/family_multiple_events.ged');
+        $this->gedcom = $this->parser->parse(\TEST_DIR . '/stresstestfiles/family/family_multiple_events.ged');
         $fam = $this->gedcom->getFam('F1');
 
         $events = $fam['F1']->getAllEven();
@@ -88,7 +88,7 @@ class FamParserTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetEvenReturnsASingleEvent()
     {
-        $this->gedcom = $this->parser->parse(\TEST_DIR.'/stresstestfiles/family/family_event_with_type.ged');
+        $this->gedcom = $this->parser->parse(\TEST_DIR . '/stresstestfiles/family/family_event_with_type.ged');
 
         $fam = $this->gedcom->getFam('F1');
 
@@ -103,7 +103,7 @@ class FamParserTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetEvenReturnsMultipleEvents()
     {
-        $this->gedcom = $this->parser->parse(\TEST_DIR.'/stresstestfiles/family/family_multiple_events.ged');
+        $this->gedcom = $this->parser->parse(\TEST_DIR . '/stresstestfiles/family/family_multiple_events.ged');
 
         $fam = $this->gedcom->getFam('F1');
 
@@ -117,5 +117,18 @@ class FamParserTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('First civil marriage', $event1->getType());
         $this->assertEquals('Second civil marriage', $event2->getType());
+    }
+
+    /**
+     * Test a family event with a custom tag is parsed.
+     */
+    public function testFamilyEventWithExtensionTagIsParsed()
+    {
+        $this->gedcom = $this->parser->parse(\TEST_DIR . '/stresstestfiles/family/family_with_extension_tag.ged');
+
+        $fam = $this->gedcom->getFam('F1');
+
+        $extensionTag = $fam['F1']->getExtensionTag('NAME');
+        $this->assertEquals('A random family', $extensionTag);
     }
 }

--- a/tests/library/Gedcom/FamWriterTest.php
+++ b/tests/library/Gedcom/FamWriterTest.php
@@ -41,9 +41,10 @@ class FamWriterTest extends TestCase
     public static function families()
     {
         return [
-            [\TEST_DIR.'/stresstestfiles/family/family_event_no_type.ged'],
-            [\TEST_DIR.'/stresstestfiles/family/family_event_with_type.ged'],
-            [\TEST_DIR.'/stresstestfiles/family/family_multiple_events.ged'],
+            [\TEST_DIR . '/stresstestfiles/family/family_event_no_type.ged'],
+            [\TEST_DIR . '/stresstestfiles/family/family_event_with_type.ged'],
+            [\TEST_DIR . '/stresstestfiles/family/family_multiple_events.ged'],
+            [\TEST_DIR . '/stresstestfiles/family/family_with_extension_tag.ged'],
         ];
     }
 }

--- a/tests/stresstestfiles/family/family_with_extension_tag.ged
+++ b/tests/stresstestfiles/family/family_with_extension_tag.ged
@@ -1,0 +1,3 @@
+0 @F1@ FAM 
+1 _NAME A random family
+0 TRLR


### PR DESCRIPTION
As specified on the GEDCOM docs on `Extensions` (https://gedcom.io/specifications/FamilySearchGEDCOMv7.html#extensions) it is possible to defined custom tags that start with underscore (ie: `_NAME`)

This PR adds the new `Extendable` interface to support extensions and implements it for the `Fam` record, parser and writer.

@curtisdelicata 