### PR TITLE
Allow empty age tags

### DIFF
--- a/src/Parser/Indi/Even.php
+++ b/src/Parser/Indi/Even.php
@@ -79,7 +79,7 @@ class Even extends \Gedcom\Parser\Component
                     $even->setCaus(trim((string) $record[2]));
                     break;
                 case 'AGE':
-                    $even->setAge(trim((string) $record[2]));
+                    $even->setAge($record);
                     break;
                 case 'AGNC':
                     $even->setAgnc(trim((string) $record[2]));

--- a/src/Record/Indi/Even.php
+++ b/src/Record/Indi/Even.php
@@ -197,9 +197,13 @@ class Even extends \Gedcom\Record implements Record\Objectable, Record\Sourceabl
      *
      * @return Even
      */
-    public function setAge($age = '')
+    public function setAge($record)
     {
-        $this->age = $age;
+        if (isset($record[2])) {
+            $this->age = trim($record[2]);
+        } else {
+            $this->age = '';
+        }
 
         return $this;
     }


### PR DESCRIPTION
According to the specification:

`Age payloads may also be omitted entirely if no suitable form is known but a substructure (such as a [PHRASE](https://gedcom.io/specifications/FamilySearchGEDCOMv7.html#PHRASE)) is desired.
`

This change avoids a fatal error when age is present but empty.

@curtisdelicata 