### PR TITLE
Removed forward statement at beginning of parsing, because it ommits reading the first line of the import, fixes #82

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -46,8 +46,6 @@ class Parser implements ParserInterface
         $this->currentLine = 0;
         $this->errors = [];
 
-        $this->forward();
-
         while (!$this->eof()) {
             $record = $this->getCurrentLineRecord();
 


### PR DESCRIPTION
Fixes #82