### PR TITLE
Bugfix79 remove mixed type from abstract class Component

### DIFF
--- a/src/Parser/Component.php
+++ b/src/Parser/Component.php
@@ -8,5 +8,5 @@ use Gedcom\Parser as GedcomParser;
 
 abstract class Component
 {
-    abstract public static function parse(GedcomParser $parser): mixed;
+    abstract public static function parse(GedcomParser $parser);
 }


### PR DESCRIPTION
Avoid PHP error during GEDCOM parsing, fixes #79