### PR TITLE
Bugfix80: Fix parsing 1 NOTE text

### DIFF
--- a/src/Parser/Component.php
+++ b/src/Parser/Component.php
@@ -8,5 +8,5 @@ use Gedcom\Parser as GedcomParser;
 
 abstract class Component
 {
-    abstract public static function parse(GedcomParser $parser): mixed;
+    abstract public static function parse(GedcomParser $parser);
 }

--- a/src/Parser/NoteRef.php
+++ b/src/Parser/NoteRef.php
@@ -35,7 +35,6 @@ class NoteRef extends \Gedcom\Parser\Component
             $note->setIsReference(true);
             $note->setNote($parser->normalizeIdentifier($record[2]));
         } else {
-            $parser->getCurrentLine();
             $note->setIsReference(false);
             $note->setNote($parser->parseMultiLineRecord());
         }


### PR DESCRIPTION
Avoid PHP error if parsing "1 NOTE text", fixes #80