### PR TITLE
convertEventToGedcomX method needs to handle INDI events and FAM events as well

### DIFF
--- a/src/GedcomX/Generator.php
+++ b/src/GedcomX/Generator.php
@@ -308,7 +308,7 @@ class Generator
         return $this->gedcomToGedcomxGenderTypes[strtoupper($sex)] ?? 'http://gedcomx.org/Unknown';
     }
 
-    private function convertEventToGedcomX(Even $event, string $eventType): ?array
+    private function convertEventToGedcomX(mixed $event, string $eventType): ?array
     {
         $gedcomxFactType = $this->mapGedcomEventTypeToFactType($eventType);
         if (!$gedcomxFactType) {


### PR DESCRIPTION
convertEventToGedcomX method needs to handle INDI events and FAM events as well. Therefore, event type is chosen as mixed